### PR TITLE
Add config folder and options.yml

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,15 @@
+# Configuration files
+This directory contains files used to configure the PingAuthorize Policy Editor.
+
+## options.yml
+This file, used by the `setup` command-line tool, allows system administrators to alter the output `configuration.yml` 
+file generated during `setup`. It uses the YAML file format, and is provided to `setup` via the following shell command
+fragment:
+
+```
+bin/setup --optionsFile options.yml <additional-setup-arguments>
+```
+
+The file is included with the standard PingAuthorize Policy Editor distribution, and is additionally provided here
+for reference.
+

--- a/config/options.yml
+++ b/config/options.yml
@@ -1,0 +1,159 @@
+# Example setup options that may be overlaid during setup
+# using the --optionsFile option. Run `setup --help` for further
+# instructions.
+core:
+  # Add policy configuration keys here. The value for a policy 
+  # configuration key may be provided via an environment variable 
+  # using the notation '${environment-variable}'.
+  #
+  #  PolicyConfigurationKeyName: PolicyConfigurationKeyValue
+keystores:
+  # Define key stores used by policy information providers here.
+  #
+  #  - name: CustomKeyStore
+  #    resource: /path/to/custom-keystore.jks
+  #    password: keystore-password
+truststores:
+  # Define trust stores used by policy information providers here.
+  #
+  #  - name: CustomTrustStore
+  #    resource: /path/to/custom-truststore.jks
+  #    password: truststore-password
+deploymentPackageData:
+  # Define a key store to use for signing deployment packages here.
+  #
+  #  contentType: json
+  #  keystore:
+  #    resource: /path/to/deployment-package-signing-keystore.jks
+  #    password: keystore-password
+  #  securityLevel: signed
+  #  signingKey:
+  #    alias: signing-cert-alias
+  #    password: private-key-password
+deploymentPackageStores:
+  # Define deployment package store publishing targets here.
+  #
+  # - name: Filesystem store
+  #   description: File system directory store
+  #   type: filesystem
+  #   path: /path/to/deployment-package-store/
+  # - name: Signed filesystem store
+  #   description: Signed file system directory store
+  #   type: filesystem
+  #   path: /path/to/signed-deployment-package-store/
+  #   securityLevel: signed
+  #   keystore:
+  #     resource: /path/to/deployment-package-signing-keystore.jks
+  #     password: keystore-password
+  #   signingKey:
+  #     alias: signing-cert-alias
+  #     password: private-key-password
+  # - name: S3 bucket store
+  #   description: AWS S3 bucket store
+  #   type: s3bucket
+  #   securityLevel: unsigned
+  #   config:
+  #     bucket: store-bucket-name
+  #     prefix: store-prefix
+  #     endpoint: https://s3.amazonaws.com
+  #     region: us-east-2
+  #     accessKey: aws-access-key
+  #     secretKey: aws-secret-key
+  #
+  # - name: Azure blob storage store
+  #   description: Microsoft Azure blob storage store
+  #   type: azure
+  #   securityLevel: unsigned
+  #   config:
+  #     connection-string: DefaultEndpointsProtocol=[http|https];AccountName=myAccountName;AccountKey=myAccountKey
+  #     container: azure-blob-storage-container-name
+  #     prefix: azure-blob-storage-prefix
+  #
+securityHeaders:
+  # Configure the values that the Policy Administration GUI will set in its
+  # responses for the X-Frame-Options, Content-Security-Policy, and/or
+  # Access-Control-Allow-Origin HTTP security headers here.
+  #
+  # X-Frame-Options: "deny"
+  # Content-Security-Policy: "default-src https:"
+  # Access-Control-Allow-Origin: "*"
+logging:
+  level: INFO
+  loggers:
+    "DataNucleus": ERROR
+    "DataNucleus.Enhancer": "OFF"
+    "org.glassfish.jersey.internal.Errors": ERROR
+    "com.symphonicsoft.policyanalysis.PolicyTranslator": ERROR
+    # If instructed to do so by Ping Identity Support, you can enable
+    # additional logging for HTTP errors by uncommenting one of the following
+    # lines and running setup. This will cause stack trace details about HTTP
+    # errors to be recorded to logs/debug.log.
+    #
+    # To enable additional logging for HTTP 50x errors only:
+    # "com.symphonicsoft.rest.BaseExceptionMapper": ERROR
+    #
+    # To enable additional logging for HTTP 40x and 50x errors:
+    # "com.symphonicsoft.rest.BaseExceptionMapper": DEBUG
+    "DECISION_AUDIT_LOG":
+      level: INFO
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: logs/decision-audit.log
+          archive: true
+          maxFileSize: 250MB
+          archivedLogFilenamePattern: logs/decision-audit.%i.log.gz
+          archivedFileCount: 10
+          logFormat: "[%date{ISO8601}] %msg%n"
+    "DECISION_DIAGNOSTIC_LOG":
+      level: "OFF"
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: logs/decision-diagnostic.log
+          archive: true
+          maxFileSize: 250MB
+          archivedLogFilenamePattern: logs/decision-audit.%i.log.gz
+          archivedFileCount: 10
+          logFormat: "%msg%n"
+    "MANAGEMENT_AUDIT":
+      level: INFO
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: logs/management-audit.log
+          archive: false
+          archivedLogFilenamePattern: logs/management-audit.%i.log.gz
+          archivedFileCount: 10
+          logFormat: "[%date{ISO8601}] %msg%n"
+    metrics:
+      additive: false
+      appenders:
+        - type: file
+          currentLogFilename: logs/metrics.log
+          maxFileSize: 250MB
+          archive: true
+          archivedLogFilenamePattern: logs/metrics.%i.log.gz
+          archivedFileCount: 10
+          logFormat: "logger=metrics, timestamp=%date{yyyyMMdd'T'HHmmss.SSS}, %msg%n"
+  appenders:
+    - type: console
+      threshold: INFO
+      target: stdout
+      logFormat: "%-5level [%date{ISO8601}] %c: %msg%n"
+    - type: file
+      threshold: DEBUG
+      currentLogFilename: logs/debug.log
+      maxFileSize: 250MB
+      archive: true
+      archivedLogFilenamePattern: logs/debug.%i.log.gz
+      archivedFileCount: 10
+      logFormat: "%-5level [%date{ISO8601}] [%thread] %c: %msg%n"
+    - type: file
+      threshold: INFO
+      currentLogFilename: logs/authorize-pe.log
+      maxFileSize: 250MB
+      archive: true
+      archivedLogFilenamePattern: logs/authorize-pe.%i.log.gz
+      archivedFileCount: 10
+      logFormat: "%-5level [%date{ISO8601}] %c: %msg%n"


### PR DESCRIPTION
Please see the GitHub rendered content here: https://github.com/pingidentity/pingauthorize-contrib/tree/DS-44583-options-yml/config

Commit message:
```
This adds a config folder and options.yml for reference.

Reviewer: Andrew Giorgio
Reviewer: Anne Smith

JiraIssue: DS-44583
```